### PR TITLE
Update SixLabors.ImageSharp and CefSharp.Wpf.NETCore versions to address known vulnerabilities

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
 </Project>

--- a/OBB-WPF/OBB-WPF.csproj
+++ b/OBB-WPF/OBB-WPF.csproj
@@ -23,8 +23,8 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CefSharp.Wpf.NETCore" Version="120.1.110" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="CefSharp.Wpf.NETCore" Version="134.3.90" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update dependency CefSharp.Wpf.NETCore from 120.1.110 to 134.3.90 address known vulnerability:
 - [ref] https://github.com/advisories/GHSA-f87w-3j5w-v58p

Update dependency SixLabors.ImageSharp from 3.1.5 to 3.1.7 to address a know vulnerability:
 - [ref] https://github.com/advisories/GHSA-2cmq-823j-5qj8