### PR TITLE
Fix part name mismatches in single-part filtering

### DIFF
--- a/AOABO/Omnibus/OmnibusBuilder.cs
+++ b/AOABO/Omnibus/OmnibusBuilder.cs
@@ -140,10 +140,10 @@ namespace AOABO.Omnibus
                 {
                     if (partScope == PartToProcess.PartOne && part.Name.Equals("Daughter of a Soldier")) continue;
                     if (partScope == PartToProcess.PartTwo && part.Name.Equals("Apprentice Shrine Maiden")) continue;
-                    if (partScope == PartToProcess.PartThree && part.Name.Equals("Adoptive Daughter of an Archduke")) continue;
-                    if (partScope == PartToProcess.PartFour && part.Name.Equals("Founder of the Royal Academy's So-Called Library Commmittee")) continue;
+                    if (partScope == PartToProcess.PartThree && part.Name.Equals("Adopted Daughter of an Archduke")) continue;
+                    if (partScope == PartToProcess.PartFour && part.Name.Equals("Founder of the Royal Academy's So-Called Library Committee")) continue;
                     if (partScope == PartToProcess.PartFive && part.Name.Equals("Avatar of a Goddess")) continue;
-                    if (partScope == PartToProcess.Hannelore && part.Name.Equals("Hannelore's Fifth Year At The Royal Academy")) continue;
+                    if (partScope == PartToProcess.Hannelore && part.Name.Equals("Hannelore's Fifth Year at the Royal Academy")) continue;
 
                     omnibus.Chapters.Remove(part);
                 }


### PR DESCRIPTION
## Summary
- Fix three hardcoded part name strings in `OmnibusBuilder.BuildOmnibus()` that don't match the JSON configuration, causing parts 3, 4, and Hannelore to be silently filtered out when building single-part omnibuses:
  - **Part 3:** "Adoptive" → "Adopted" Daughter of an Archduke
  - **Part 4:** "Commmittee" → "Committee" (triple-m typo)
  - **Hannelore:** "At The" → "at the" in title capitalization

## Test plan
- Build a single-part omnibus for Part 3 (Adopted Daughter of an Archduke)
- Build a single-part omnibus for Part 4 (Library Committee)
- Build a single-part omnibus for Hannelore's Fifth Year